### PR TITLE
retrieve prNumber from context object

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,16 +7,9 @@ const main = async () => {
   const repoOwner = context.repo.owner;
   const githubToken = core.getInput("github-token");
   const testCommand = core.getInput("test-command") || "npx jest";
+  const prNumber = context.payload.number;
 
   const githubClient = new GitHub(githubToken);
-  const commitPRs = await githubClient.repos.listPullRequestsAssociatedWithCommit(
-    {
-      repo: repoName,
-      owner: repoOwner,
-      commit_sha: context.sha
-    }
-  );
-  const prNumber = commitPRs.data[0].number;
 
   const codeCoverage = execSync(testCommand).toString();
   let coveragePercentage = execSync(


### PR DESCRIPTION
This PR resolves this issue #3.

The pull request number can be accessed from the context object