### PR TITLE
Use markdown to comment in PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,11 @@ const main = async () => {
   ).toString();
   coveragePercentage = parseFloat(coveragePercentage).toFixed(2);
 
-  const commentBody = `<p>Total Coverage: <code>${coveragePercentage}</code></p>
-<details><summary>Coverage report</summary>
-<p>
-<pre>${codeCoverage}</pre>
-</p>
-</details>`;
+  const commentBody = `### Total Coverage: ${coveragePercentage}
+
+**Coverage report**
+
+${codeCoverage}`;
 
   await githubClient.issues.createComment({
     repo: repoName,

--- a/index.js
+++ b/index.js
@@ -24,11 +24,9 @@ const main = async () => {
   ).toString();
   coveragePercentage = parseFloat(coveragePercentage).toFixed(2);
 
-  const commentBody = `### Total Coverage: ${coveragePercentage}
+  const commentBody = `#### Total Coverage: ${coveragePercentage}
 
-**Coverage report**
-
-${codeCoverage}`;
+<pre>${codeCoverage}</pre>`;
 
   await githubClient.issues.createComment({
     repo: repoName,


### PR DESCRIPTION
The current html markup makes the tests results to be collased. This change uses markdown instead, since the jest results should render better as markdown.